### PR TITLE
E0d/django upgrade

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,5 @@
-django<4.0
+#django<4.0
+django==4.2.21
 openedx-filters
 pycryptodomex
 pyjwkest

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     url="https://github.com/openedx/openedx-ltistore",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["django<4.0"],
+    install_requires=["django==4.2.21"],
     python_requires=">=3.8",
     license="AGPL 3.0",
     zip_safe=False,


### PR DESCRIPTION
Opening to start the conversation about upgrading Django for this plugin.  The current state causes problems in Tutor main.  I've pinned to the same version that the platform is currently pinned to, tests pass, plugin deploys.  I can interact with the models in Django admin, but haven't been able to verify it's fully functional yet.